### PR TITLE
fix: add America/St_Johns handling to tzOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This change log follows the format documented in [Keep a CHANGELOG].
 [semantic versioning]: http://semver.org/
 [keep a changelog]: http://keepachangelog.com/
 
+## v1.0.3 - 2024-09-22
+
+This is yet another critical bug-fix release. Thank you to all the people who sent PRs and reported their issues.
+
+### Fixes
+
+- [Fixes negative fractional time zones like `America/St_Johns`](https://github.com/date-fns/tz/pull/7). Kudos to [@allohamora](https://github.com/allohamora)!
+
 ## v1.0.2 - 2024-09-14
 
 This release fixes a couple of critical bugs in the previous release.

--- a/src/tzOffset/index.ts
+++ b/src/tzOffset/index.ts
@@ -25,14 +25,9 @@ export function tzOffset(timeZone: string | undefined, date: Date): number {
     const offsetStr = format(date).slice(6);
     if (offsetStr in offsetCache) return offsetCache[offsetStr]!;
 
-    const [hours, minutes = 0] = offsetStr.split(":").map(Number);
-    
-    // type-guard
-    if (hours === undefined) {
-      return NaN;
-    }
-
-    return (offsetCache[offsetStr] = hours > 0 ? hours * 60 + minutes : hours * 60 - minutes);
+    const [hours = NaN, minutes = 0] = offsetStr.split(":").map(Number);
+    return (offsetCache[offsetStr] =
+      hours > 0 ? hours * 60 + minutes : hours * 60 - minutes);
   } catch {
     return NaN;
   }

--- a/src/tzOffset/index.ts
+++ b/src/tzOffset/index.ts
@@ -25,8 +25,14 @@ export function tzOffset(timeZone: string | undefined, date: Date): number {
     const offsetStr = format(date).slice(6);
     if (offsetStr in offsetCache) return offsetCache[offsetStr]!;
 
-    const [hours, minutes] = offsetStr.split(":").map(Number);
-    return (offsetCache[offsetStr] = hours! * 60 + (minutes || 0));
+    const [hours, minutes = 0] = offsetStr.split(":").map(Number);
+    
+    // type-guard
+    if (hours === undefined) {
+      return NaN;
+    }
+
+    return (offsetCache[offsetStr] = hours > 0 ? hours * 60 + minutes : hours * 60 - minutes);
   } catch {
     return NaN;
   }

--- a/src/tzOffset/tests.ts
+++ b/src/tzOffset/tests.ts
@@ -39,18 +39,24 @@ describe("tzOffset", () => {
     expect(tzOffset("Europe/London", date)).toBe(0);
   });
 
-  it('works with America/St_Johns for Daylight Saving Time', () => {
-    const date = new Date("2023-03-15T18:00:00.000Z");
-    expect(tzOffset("America/St_Johns", date)).toBe(-150);
-  });
-
-  it('works America/St_Johns for Standard Time', () => {
-    const date = new Date("2023-03-03T18:00:00.000Z");
-    expect(tzOffset("America/St_Johns", date)).toBe(-210);
-  });
-
   it("returns NaN if the offset the date or time zone are invalid", () => {
     expect(tzOffset("Etc/Invalid", new Date("2020-01-15T00:00:00Z"))).toBe(NaN);
     expect(tzOffset("America/New_York", new Date(NaN))).toBe(NaN);
+  });
+
+  describe("fractional time zones", () => {
+    it("works negative fractional time zones", () => {
+      const dst = new Date("2023-03-15T18:00:00.000Z");
+      const date = new Date("2023-03-03T18:00:00.000Z");
+      expect(tzOffset("America/St_Johns", dst)).toBe(-150);
+      expect(tzOffset("America/St_Johns", date)).toBe(-210);
+    });
+
+    it("works positive fractional time zones", () => {
+      const dst = new Date("2024-04-06T16:00:00.000Z");
+      const date = new Date("2024-04-06T16:30:00.000Z");
+      expect(tzOffset("Australia/Adelaide", dst)).toBe(630);
+      expect(tzOffset("Australia/Adelaide", date)).toBe(570);
+    });
   });
 });

--- a/src/tzOffset/tests.ts
+++ b/src/tzOffset/tests.ts
@@ -39,6 +39,16 @@ describe("tzOffset", () => {
     expect(tzOffset("Europe/London", date)).toBe(0);
   });
 
+  it('works with America/St_Johns for Daylight Saving Time', () => {
+    const date = new Date("2023-03-15T18:00:00.000Z");
+    expect(tzOffset("America/St_Johns", date)).toBe(-150);
+  });
+
+  it('works America/St_Johns for Standard Time', () => {
+    const date = new Date("2023-03-03T18:00:00.000Z");
+    expect(tzOffset("America/St_Johns", date)).toBe(-210);
+  });
+
   it("returns NaN if the offset the date or time zone are invalid", () => {
     expect(tzOffset("Etc/Invalid", new Date("2020-01-15T00:00:00Z"))).toBe(NaN);
     expect(tzOffset("America/New_York", new Date(NaN))).toBe(NaN);


### PR DESCRIPTION
This PR fixes incorrect America/St_Johns handling in tzOffset and refactors some code.

Before:
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/eb067bd1-558e-4a8e-a8fd-e643f8305076">

After:
<img width="767" alt="image" src="https://github.com/user-attachments/assets/25de21d3-4fc1-4b99-ae21-46cb454a2adb">
