### PR TITLE
fix: Fix the JSDoc comments on the `TZDate` and `TZDateMini` classes

### DIFF
--- a/src/date/index.js
+++ b/src/date/index.js
@@ -1,21 +1,5 @@
 import { TZDateMini } from "./mini.js";
 
-/**
- * Time zone date class. It overrides original Date functions making them
- * to perform all the calculations in the given time zone.
- *
- * It also provides new functions useful when working with time zones.
- *
- * Combined with date-fns, it allows using the class the same way as
- * the original date class.
- *
- * This complete version provides formatter functions, mirroring all original
- * methods of the `Date` class. It's build-size-heavier than `TZDateMini` and
- * should be used when you need to format a string or in an environment you
- * don't fully control (a library).
- *
- * For the minimal version, see `TZDateMini`.
- */
 export class TZDate extends TZDateMini {
   //#region static
 

--- a/src/date/index.js
+++ b/src/date/index.js
@@ -1,17 +1,20 @@
 import { TZDateMini } from "./mini.js";
 
 /**
- * UTC date class. It maps getters and setters to corresponding UTC methods,
- * forcing all calculations in the UTC time zone.
+ * Time zone date class. It overrides original Date functions making them
+ * to perform all the calculations in the given time zone.
+ *
+ * It also provides new functions useful when working with time zones.
  *
  * Combined with date-fns, it allows using the class the same way as
  * the original date class.
  *
- * This complete version provides not only getters, setters,
- * and `getTimezoneOffset`, but also the formatter functions, mirroring
- * all original `Date` functionality. Use this version when you need to format
- * a string or in an environment you don't fully control (a library).
- * For a minimal version, see `UTCDateMini`.
+ * This complete version provides formatter functions, mirroring all original
+ * methods of the `Date` class. It's build-size-heavier than `TZDateMini` and
+ * should be used when you need to format a string or in an environment you
+ * don't fully control (a library).
+ *
+ * For the minimal version, see `TZDateMini`.
  */
 export class TZDate extends TZDateMini {
   //#region static

--- a/src/date/mini.js
+++ b/src/date/mini.js
@@ -1,19 +1,5 @@
 import { tzOffset } from "../tzOffset/index.ts";
 
-/**
- * Time zone date class. It overrides original Date functions making them
- * to perform all the calculations in the given time zone.
- *
- * It also provides new functions useful when working with time zones.
- *
- * Combined with date-fns, it allows using the class the same way as
- * the original date class.
- *
- * This minimal version provides complete functionality required for date-fns
- * and excludes build-size-heavy formatter functions.
- *
- * For the complete version, see `TZDate`.
- */
 export class TZDateMini extends Date {
   //#region static
 

--- a/src/date/mini.js
+++ b/src/date/mini.js
@@ -1,5 +1,19 @@
 import { tzOffset } from "../tzOffset/index.ts";
 
+/**
+ * Time zone date class. It overrides original Date functions making them
+ * to perform all the calculations in the given time zone.
+ *
+ * It also provides new functions useful when working with time zones.
+ *
+ * Combined with date-fns, it allows using the class the same way as
+ * the original date class.
+ *
+ * This minimal version provides complete functionality required for date-fns
+ * and excludes build-size-heavy formatter functions.
+ *
+ * For the complete version, see `TZDate`.
+ */
 export class TZDateMini extends Date {
   //#region static
 


### PR DESCRIPTION
I just noticed that the doc comment on the `TZDate` class (in the .js file) is still the `UTCDate`, which I assume it was forked from. However, I also noticed that the correct comment was on the declaration file for the class, so I just replaced the one on the JS class with the other one.

I also noticed that there was no doc comment on the `TZDateMini` class, so I copied that one as well.

Alternatively, maybe you actually don't want to include them at all on the JS file versions? I'm not really sure how they interact if someone is using a non-typescript project. So if you'd rather have me remove both of them, I can update it to that instead. I just figured a correct doc comment was better than an incorrect one haha.