### PR TITLE
performance: fix tzOffset cache not working for UTC offset strings

### DIFF
--- a/src/tzOffset/index.ts
+++ b/src/tzOffset/index.ts
@@ -16,6 +16,8 @@ const offsetCache: Record<string, number> = {};
  * @returns UTC offset in minutes
  */
 export function tzOffset(timeZone: string | undefined, date: Date): number {
+  if (timeZone! in offsetCache) return offsetCache[timeZone!]!;
+
   try {
     const format = (offsetFormatCache[timeZone!] ||= new Intl.DateTimeFormat(
       "en-GB",
@@ -29,7 +31,6 @@ export function tzOffset(timeZone: string | undefined, date: Date): number {
   } catch {
     // Fallback to manual parsing if the runtime doesn't support ±HH:MM/±HHMM/±HH
     // See: https://github.com/nodejs/node/issues/53419
-    if (timeZone! in offsetCache) return offsetCache[timeZone!]!;
     const captures = timeZone?.match(offsetRe);
     if (captures) return calcOffset(timeZone!, captures.slice(1));
 


### PR DESCRIPTION
### Problem
When passing a UTC offset string like `+00:00` to the `tzOffset` function, the cache is not used properly.
This causes significant performance degradation on Android devices 😓 

### Benchmark

#### `new TZDate()`
```
const start = new Date();
new TZDate(new Date(), "+00:00");
const end = new Date();

console.log(end - start);

// iOS (React Native):      iPhone 11 -> 0ms
// Android (React Native):  Pixel 7a -> 20ms, Galaxy A21 SC-42A -> 7ms, Redmi 12 -> 65ms
//                          (After modification, all 0ms.)
```

#### `Intl.DateTimeFormat` 
```
const start = new Date();
[...Array(1000)].forEach(() => {
  try {
    new Intl.DateTimeFormat("en-GB", {
      timeZone: "+00:00",
      hour: "numeric",
      timeZoneName: "longOffset",
    }).format;
  } catch {}
});
const end = new Date();

console.log(end - start);

// Chrome:                  MacBook Pro 2020 -> 152ms
// iOS (React Native):      iPhone 11 -> 20ms
// Android (React Native):  Pixel 7a -> 5087ms, Galaxy A21 SC-42A -> 2027ms, Redmi 12 -> 5098ms
```