### PR TITLE
fix: don't directly override the native `setTime` method

### DIFF
--- a/src/date/mini.js
+++ b/src/date/mini.js
@@ -13,22 +13,22 @@ export class TZDateMini extends Date {
     this.internal = new Date();
 
     if (isNaN(tzOffset(this.timeZone, this))) {
-      this.setTime(NaN);
+      this.setCustomTime(NaN);
     } else {
       if (!args.length) {
-        this.setTime(Date.now());
+        this.setCustomTime(Date.now());
       } else if (
         typeof args[0] === "number" &&
         (args.length === 1 ||
           (args.length === 2 && typeof args[1] !== "number"))
       ) {
-        this.setTime(args[0]);
+        this.setCustomTime(args[0]);
       } else if (typeof args[0] === "string") {
-        this.setTime(+new Date(args[0]));
+        this.setCustomTime(+new Date(args[0]));
       } else if (args[0] instanceof Date) {
-        this.setTime(+args[0]);
+        this.setCustomTime(+args[0]);
       } else {
-        this.setTime(+new Date(...args));
+        this.setCustomTime(+new Date(...args));
         adjustToSystemTZ(this, NaN);
         syncToInternal(this);
       }
@@ -57,7 +57,8 @@ export class TZDateMini extends Date {
 
   //#region time
 
-  setTime(time) {
+  // NOTE: we can't directly override the native `setTime` method here, because it will be invoked internally in many of other native `Date` object methods, if we do, then it's possible to cause hidden bugs
+  setCustomTime(time) {
     Date.prototype.setTime.apply(this, arguments);
     syncToInternal(this);
     return +this;

--- a/src/date/tests.ts
+++ b/src/date/tests.ts
@@ -317,12 +317,12 @@ describe("TZDate", () => {
         const nativeDate = new Date(2020, 0, 1);
         {
           const date = new TZDate(defaultDateStr, "Asia/Singapore");
-          date.setTime(+nativeDate);
+          date.setCustomTime(+nativeDate);
           expect(+date).toBe(+nativeDate);
         }
         {
           const date = new TZDate(defaultDateStr, "America/New_York");
-          date.setTime(+nativeDate);
+          date.setCustomTime(+nativeDate);
           expect(+date).toBe(+nativeDate);
         }
       });
@@ -333,7 +333,7 @@ describe("TZDate", () => {
         const date = new TZDate(defaultDateStr, "Asia/Singapore");
         expect(date.toISOString()).toEqual("1987-02-11T08:00:00.000+08:00");
 
-        date.setTime(+nativeDate);
+        date.setCustomTime(+nativeDate);
         expect(+date).toBe(+nativeDate);
         expect(date.toISOString()).toEqual("2020-01-01T06:00:00.000+08:00");
       });


### PR DESCRIPTION
### Context

Issue: https://github.com/date-fns/tz/issues/50

We can't directly override the native `setTime` method, because it's called internally in many of other native `Date` object methods, e.g. the `setFullYear`, etc, when causes the extra logic in the overriden `setTime` method gets executed redundantly and then cause bugs futher.

### Changes

- Rename the `setTime` method in the `TZDateMini` class to the `setCustomTime`
- Update the corresponding test cases