### PR TITLE
Fix Node16 ModuleResolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build: prepare-build
 build-cts:
 	@find lib -name '*.d.ts' | while read file; do \
 		new_file=$${file%.d.ts}.d.cts; \
-		cp $$file $$new_file; \
+		sed 's/\.js"/\.cjs"/g; s/\.ts"/\.cts"/g' $$file > $$new_file; \
 	done
 
 prepare-build:


### PR DESCRIPTION
Resolves https://github.com/date-fns/tz/issues/60

Replaces `.ts` and `.js` imports within the `.cts` files to import from the corresponding `.cts` and `.cjs` imports.

Tested locally and the tsc compiler seems to be happy.

Same issue as in: https://github.com/date-fns/date-fns/pull/4043