### PR TITLE
Initiate internal Date with a static value

### DIFF
--- a/src/date/mini.js
+++ b/src/date/mini.js
@@ -4,13 +4,13 @@ export class TZDateMini extends Date {
   //#region static
 
   constructor(...args) {
-    super();
+    super(0);
 
     if (args.length > 1 && typeof args[args.length - 1] === "string") {
       this.timeZone = args.pop();
     }
 
-    this.internal = new Date();
+    this.internal = new Date(0);
 
     if (isNaN(tzOffset(this.timeZone, this))) {
       this.setTime(NaN);


### PR DESCRIPTION
This PR modifies the constructor of `TZDateMini` to create the internal `Date` with a static value.

In frameworks like Next.js which monitors the use of "dynamic APIs", passing static arguments to the  `TZDate` or `TZDateMini` constructors still result in rendering errors similar to the below:

> [!CAUTION]
> Route "/some/path/page.tsx" used `new Date()` before accessing either uncached data (e.g. `fetch()`) or
Request data (e.g. `cookies()`, `headers()`, `connection()`, and `searchParams`).
> 
> Accessing the current time in a Server Component requires reading one of these data sources first.
> Alternatively, consider moving this expression into a Client Component or Cache Component.
> See more info here: https://nextjs.org/docs/messages/next-prerender-current-time

The simple change in this PR fixes the issue.

All tests are passing and there should be no differences in behavior.